### PR TITLE
fixing issue #45 adding InsertXpmPageMarkup extension method

### DIFF
--- a/source/DD4T.MVC4/DD4T.MVC4.csproj
+++ b/source/DD4T.MVC4/DD4T.MVC4.csproj
@@ -36,43 +36,43 @@
   <ItemGroup>
     <Reference Include="DD4T.ContentModel, Version=2.2.3.0, Culture=neutral, PublicKeyToken=4450e3c7f68bf872, processorArchitecture=MSIL">
       <HintPath>..\packages\DD4T.Model.2.2.3\lib\net45\DD4T.ContentModel.dll</HintPath>
-	  <Private>False</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="DD4T.ContentModel.Contracts, Version=2.2.3.0, Culture=neutral, PublicKeyToken=4450e3c7f68bf872, processorArchitecture=MSIL">
       <HintPath>..\packages\DD4T.Model.2.2.3\lib\net45\DD4T.ContentModel.Contracts.dll</HintPath>
-	  <Private>False</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="DD4T.ContentModel.XmlSerializers, Version=2.2.3.0, Culture=neutral, PublicKeyToken=4450e3c7f68bf872, processorArchitecture=MSIL">
       <HintPath>..\packages\DD4T.Model.2.2.3\lib\net45\DD4T.ContentModel.XmlSerializers.dll</HintPath>
-	  <Private>False</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="DD4T.Core.Contracts, Version=2.2.10.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DD4T.Core.2.2.10\lib\net45\DD4T.Core.Contracts.dll</HintPath>
-	  <Private>False</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="DD4T.Factories, Version=2.2.10.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DD4T.Core.2.2.10\lib\net45\DD4T.Factories.dll</HintPath>
-	  <Private>False</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="DD4T.Serialization, Version=2.2.3.0, Culture=neutral, PublicKeyToken=4450e3c7f68bf872, processorArchitecture=MSIL">
       <HintPath>..\packages\DD4T.Model.2.2.3\lib\net45\DD4T.Serialization.dll</HintPath>
-	  <Private>False</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="DD4T.Utils, Version=2.2.10.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DD4T.Core.2.2.10\lib\net45\DD4T.Utils.dll</HintPath>
-	  <Private>False</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="DD4T.ViewModels, Version=2.2.10.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DD4T.Core.2.2.10\lib\net45\DD4T.ViewModels.dll</HintPath>
-	  <Private>False</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
-	  <Private>False</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.10.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-	  <Private>False</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
@@ -82,27 +82,27 @@
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Helpers, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.WebPages.2.0.20710.0\lib\net40\System.Web.Helpers.dll</HintPath>
-	  <Private>False</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System.Web.Mvc, Version=4.0.0.1, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.Mvc.4.0.40804.0\lib\net40\System.Web.Mvc.dll</HintPath>
-	  <Private>False</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System.Web.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.Razor.2.0.20710.0\lib\net40\System.Web.Razor.dll</HintPath>
-	  <Private>False</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System.Web.WebPages, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.WebPages.2.0.20710.0\lib\net40\System.Web.WebPages.dll</HintPath>
-	  <Private>False</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System.Web.WebPages.Deployment, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.WebPages.2.0.20710.0\lib\net40\System.Web.WebPages.Deployment.dll</HintPath>
-	  <Private>False</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System.Web.WebPages.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.WebPages.2.0.20710.0\lib\net40\System.Web.WebPages.Razor.dll</HintPath>
-	  <Private>False</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -123,6 +123,15 @@
     </Compile>
     <Compile Include="..\DD4T.MVC\Caching\WebCacheAgent.cs">
       <Link>Caching\WebCacheAgent.cs</Link>
+    </Compile>
+    <Compile Include="..\DD4T.Mvc\Configuration\IMvcConfiguration.cs">
+      <Link>Configuration\IMvcConfiguration.cs</Link>
+    </Compile>
+    <Compile Include="..\DD4T.Mvc\Configuration\MvcConfiguration.cs">
+      <Link>Configuration\MvcConfiguration.cs</Link>
+    </Compile>
+    <Compile Include="..\DD4T.Mvc\Configuration\MvcConfigurationKeys.cs">
+      <Link>Configuration\MvcConfigurationKeys.cs</Link>
     </Compile>
     <Compile Include="..\DD4T.Mvc\Controllers\DD4TControllerBase.cs">
       <Link>Controllers\DD4TControllerBase.cs</Link>

--- a/source/DD4T.MVC5/DD4T.MVC5.csproj
+++ b/source/DD4T.MVC5/DD4T.MVC5.csproj
@@ -36,43 +36,43 @@
   <ItemGroup>
     <Reference Include="DD4T.ContentModel, Version=2.2.3.0, Culture=neutral, PublicKeyToken=4450e3c7f68bf872, processorArchitecture=MSIL">
       <HintPath>..\packages\DD4T.Model.2.2.3\lib\net45\DD4T.ContentModel.dll</HintPath>
-	  <Private>False</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="DD4T.ContentModel.Contracts, Version=2.2.3.0, Culture=neutral, PublicKeyToken=4450e3c7f68bf872, processorArchitecture=MSIL">
       <HintPath>..\packages\DD4T.Model.2.2.3\lib\net45\DD4T.ContentModel.Contracts.dll</HintPath>
-	  <Private>False</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="DD4T.ContentModel.XmlSerializers, Version=2.2.3.0, Culture=neutral, PublicKeyToken=4450e3c7f68bf872, processorArchitecture=MSIL">
       <HintPath>..\packages\DD4T.Model.2.2.3\lib\net45\DD4T.ContentModel.XmlSerializers.dll</HintPath>
-	  <Private>False</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="DD4T.Core.Contracts, Version=2.2.10.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DD4T.Core.2.2.10\lib\net45\DD4T.Core.Contracts.dll</HintPath>
-	  <Private>False</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="DD4T.Factories, Version=2.2.10.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DD4T.Core.2.2.10\lib\net45\DD4T.Factories.dll</HintPath>
-	  <Private>False</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="DD4T.Serialization, Version=2.2.3.0, Culture=neutral, PublicKeyToken=4450e3c7f68bf872, processorArchitecture=MSIL">
       <HintPath>..\packages\DD4T.Model.2.2.3\lib\net45\DD4T.Serialization.dll</HintPath>
-	  <Private>False</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="DD4T.Utils, Version=2.2.10.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DD4T.Core.2.2.10\lib\net45\DD4T.Utils.dll</HintPath>
-	  <Private>False</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="DD4T.ViewModels, Version=2.2.10.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DD4T.Core.2.2.10\lib\net45\DD4T.ViewModels.dll</HintPath>
-	  <Private>False</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
-	  <Private>False</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.10.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-	  <Private>False</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
@@ -82,27 +82,27 @@
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.Helpers.dll</HintPath>
-	  <Private>False</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System.Web.Mvc, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.Mvc.5.2.3\lib\net45\System.Web.Mvc.dll</HintPath>
-	  <Private>False</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System.Web.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.Razor.3.2.3\lib\net45\System.Web.Razor.dll</HintPath>
-	  <Private>False</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System.Web.WebPages, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.dll</HintPath>
-	  <Private>False</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System.Web.WebPages.Deployment, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.Deployment.dll</HintPath>
-	  <Private>False</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
-	  <Private>False</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -123,6 +123,15 @@
     </Compile>
     <Compile Include="..\dd4t.mvc\caching\WebCacheAgent.cs">
       <Link>Caching\WebCacheAgent.cs</Link>
+    </Compile>
+    <Compile Include="..\DD4T.Mvc\Configuration\IMvcConfiguration.cs">
+      <Link>Configuration\IMvcConfiguration.cs</Link>
+    </Compile>
+    <Compile Include="..\DD4T.Mvc\Configuration\MvcConfiguration.cs">
+      <Link>Configuration\MvcConfiguration.cs</Link>
+    </Compile>
+    <Compile Include="..\DD4T.Mvc\Configuration\MvcConfigurationKeys.cs">
+      <Link>Configuration\MvcConfigurationKeys.cs</Link>
     </Compile>
     <Compile Include="..\DD4T.Mvc\Controllers\DD4TControllerBase.cs">
       <Link>Controllers\DD4TControllerBase.cs</Link>

--- a/source/DD4T.Mvc/Configuration/IMvcConfiguration.cs
+++ b/source/DD4T.Mvc/Configuration/IMvcConfiguration.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DD4T.MVC.Configuration
+{
+    public interface IMvcConfiguration
+    {
+        string ContentManagerUrl { get; }
+    }
+}

--- a/source/DD4T.Mvc/Configuration/MvcConfiguration.cs
+++ b/source/DD4T.Mvc/Configuration/MvcConfiguration.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DD4T.MVC.Configuration
+{
+    public class MvcConfiguration : IMvcConfiguration
+    {
+        public string ContentManagerUrl => ConfigurationManager.AppSettings[MvcConfigurationKeys.ContentManagerUrl];
+    }
+}

--- a/source/DD4T.Mvc/Configuration/MvcConfigurationKeys.cs
+++ b/source/DD4T.Mvc/Configuration/MvcConfigurationKeys.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DD4T.MVC.Configuration
+{
+    public struct MvcConfigurationKeys
+    {
+        public static string ContentManagerUrl => "DD4T.ContentManagerUrl";
+    }
+}

--- a/source/DD4T.Mvc/DependencyMapper.cs
+++ b/source/DD4T.Mvc/DependencyMapper.cs
@@ -1,6 +1,7 @@
 ﻿using DD4T.Core.Contracts.DependencyInjection;
 using DD4T.Mvc.Html;
 using DD4T.Mvc.ViewModels.XPM;
+using DD4T.MVC.Configuration;
 using System;
 using System.Collections.Generic;
 
@@ -13,6 +14,7 @@ namespace DD4T.Mvc
             var mappings = new Dictionary<Type, Type>();
 
             mappings.Add(typeof(IComponentPresentationRenderer), typeof(DefaultComponentPresentationRenderer));
+            mappings.Add(typeof(IMvcConfiguration), typeof(MvcConfiguration));
             mappings.Add(typeof(IXpmMarkupService), typeof(XpmMarkupService));
 
             return mappings;

--- a/source/DD4T.Mvc/ViewModels/XPM/Contracts.cs
+++ b/source/DD4T.Mvc/ViewModels/XPM/Contracts.cs
@@ -31,7 +31,7 @@ namespace DD4T.Mvc.ViewModels.XPM
         /// <param name="page">Page</param>
         /// <param name="url">tridion CM url</param>
         /// <returns>XPM Markup</returns>
-        string RenderXpmMarkupForPage(IPage page);
+        string RenderXpmMarkupForPage(IPage page, string contentManagerUrl = null);
         /// <summary>
         /// Determines if Site Edit is enabled
         /// </summary>

--- a/source/DD4T.Mvc/ViewModels/XPM/Contracts.cs
+++ b/source/DD4T.Mvc/ViewModels/XPM/Contracts.cs
@@ -31,7 +31,7 @@ namespace DD4T.Mvc.ViewModels.XPM
         /// <param name="page">Page</param>
         /// <param name="url">tridion CM url</param>
         /// <returns>XPM Markup</returns>
-        string RenderXpmMarkupForPage(IPage page, string url);
+        string RenderXpmMarkupForPage(IPage page);
         /// <summary>
         /// Determines if Site Edit is enabled
         /// </summary>

--- a/source/DD4T.Mvc/ViewModels/XPM/XpmExtensions.cs
+++ b/source/DD4T.Mvc/ViewModels/XPM/XpmExtensions.cs
@@ -22,8 +22,7 @@ namespace DD4T.Mvc.ViewModels.XPM
     /// </summary>
     public static class XpmExtensions
     {
-        private static IDD4TConfiguration configuration = DependencyResolver.Current.GetService<IDD4TConfiguration>();
-        private static IXpmMarkupService xpmMarkupService = new XpmMarkupService(configuration);
+        private static IXpmMarkupService xpmMarkupService = DependencyResolver.Current.GetService<IXpmMarkupService>();
         private static IViewModelResolver resolver = DependencyResolver.Current.GetService<IViewModelResolver>();
         private static IReflectionHelper reflectionHelper = DependencyResolver.Current.GetService<IReflectionHelper>();
         /// <summary>
@@ -123,6 +122,22 @@ namespace DD4T.Mvc.ViewModels.XPM
                 result = renderer.StartXpmEditingZone();
             }
             return result;
+        }
+
+
+        /// <summary>
+        /// Add XPM page tag to the web page
+        /// </summary>
+        /// <param name="page"></param>
+        public static MvcHtmlString InsertXpmPageMarkup(this IViewModel page)
+        {
+            if (XpmMarkupService.IsSiteEditEnabled() && page.ModelData != null && typeof(IPage).IsAssignableFrom(page.ModelData.GetType()))
+            {
+                var xpmPageTag = new MvcHtmlString(XpmExtensions.XpmMarkupService.RenderXpmMarkupForPage(
+                   (IPage)page.ModelData));
+                return xpmPageTag;
+            }
+            return MvcHtmlString.Empty;
         }
         #endregion
     }

--- a/source/DD4T.Mvc/ViewModels/XPM/XpmMarkupService.cs
+++ b/source/DD4T.Mvc/ViewModels/XPM/XpmMarkupService.cs
@@ -8,6 +8,7 @@ using DD4T.Mvc.SiteEdit;
 using DD4T.ContentModel;
 using DD4T.Mvc.ViewModels.XPM;
 using DD4T.ContentModel.Contracts.Configuration;
+using DD4T.MVC.Configuration;
 
 namespace DD4T.Mvc.ViewModels.XPM
 {
@@ -17,12 +18,16 @@ namespace DD4T.Mvc.ViewModels.XPM
     public class XpmMarkupService : IXpmMarkupService
     {
         private readonly IDD4TConfiguration _configuration;
-        public XpmMarkupService(IDD4TConfiguration configuration)
+        private readonly IMvcConfiguration _mvcConfiguration;
+        public XpmMarkupService(IDD4TConfiguration configuration, IMvcConfiguration mvcConfiguration)
         {
             if (configuration == null)
                 throw new ArgumentNullException("configuration");
+            if (mvcConfiguration == null)
+                throw new ArgumentNullException("mvcConfiguration");
 
             _configuration = configuration;
+            _mvcConfiguration = mvcConfiguration;
         }
         public string RenderXpmMarkupForField(IField field, int index = -1)
         {     
@@ -35,9 +40,9 @@ namespace DD4T.Mvc.ViewModels.XPM
         {
             return XPMTags.GenerateSiteEditComponentTag(cp);
         }
-        public string RenderXpmMarkupForPage(IPage page, string url)
+        public string RenderXpmMarkupForPage(IPage page)
         {
-            return XPMTags.GenerateSiteEditPageTag(page, url);
+            return XPMTags.GenerateSiteEditPageTag(page, _mvcConfiguration.ContentManagerUrl);
         }
 
         public bool IsSiteEditEnabled()

--- a/source/DD4T.Mvc/ViewModels/XPM/XpmMarkupService.cs
+++ b/source/DD4T.Mvc/ViewModels/XPM/XpmMarkupService.cs
@@ -40,10 +40,11 @@ namespace DD4T.Mvc.ViewModels.XPM
         {
             return XPMTags.GenerateSiteEditComponentTag(cp);
         }
-        public string RenderXpmMarkupForPage(IPage page)
+        public string RenderXpmMarkupForPage(IPage page, string contentManagerUrl = null)
         {
-            return XPMTags.GenerateSiteEditPageTag(page, _mvcConfiguration.ContentManagerUrl);
+            return XPMTags.GenerateSiteEditPageTag(page, contentManagerUrl ?? _mvcConfiguration.ContentManagerUrl);
         }
+
 
         public bool IsSiteEditEnabled()
         {


### PR DESCRIPTION
Introduced HtmlHelper extension method InsertXpmPageMarkup, analogous to the StartXpmEditingZone and XpmEditableField methods we had already. This is done to make the process more consistent. In this blog (https://yatb.mitza.net/2016/03/xpm-dd4t-2-net.html) Mihai Cadariu describes how to do it now, and I think this new method will improve the process.

@albertromkes care to review this one?